### PR TITLE
Remove reload page when navigating to `upload` path

### DIFF
--- a/components/navigation.tsx
+++ b/components/navigation.tsx
@@ -27,24 +27,19 @@ export function Navigation() {
   const { connected } = useWallet();
   const { openWalletDialog } = useWalletDialog();
 
-  const navigateTo = (href: string, reload: boolean) => {
-    if (reload) {
-      // Use window.location to force full page reload for COOP/COEP headers
-      globalThis.location.assign(href);
-    } else {
-      router.push(href);
-    }
+  const navigateTo = (href: string) => {
+    router.push(href);
   };
 
   const handleNavClick = (item: NavItem) => {
     // If clicking profile or upload and not connected, show wallet dialog
     // After connection, navigate to the intended destination
     if ((item.isProfile || item.isUpload) && !connected) {
-      openWalletDialog(() => navigateTo(item.href, item.isUpload ?? false));
+      openWalletDialog(() => navigateTo(item.href));
       return;
     }
 
-    navigateTo(item.href, item.isUpload ?? false);
+    navigateTo(item.href);
   };
 
   return (


### PR DESCRIPTION
The flow of using the app n mobile is:

1. User goes to https://shelby-breakpoint.verel.app
2. User clicks on `upload` (or `profile`) 
3. Wallet connector pops up 
4. User clicks `connect` 
5. The app redirects the user to the in-app explorer page in the wallet native app


The reload breaks the app flow, since it does not redirect the user to the in-app explorer page but just reloads the page.