### PR TITLE
Add x handle to profile info

### DIFF
--- a/actions/profiles.ts
+++ b/actions/profiles.ts
@@ -25,6 +25,7 @@ export type SaveProfileParams = {
   username?: string | null;
   bio?: string | null;
   email?: string | null;
+  x_handle?: string | null;
   marketingOptIn?: boolean;
   recaptchaToken?: string;
 };
@@ -35,6 +36,7 @@ export async function saveProfile(params: SaveProfileParams) {
     username,
     bio,
     email,
+    x_handle,
     marketingOptIn,
     recaptchaToken,
   } = params;
@@ -58,6 +60,7 @@ export async function saveProfile(params: SaveProfileParams) {
         username,
         bio,
         email,
+        x_handle,
         marketingOptIn: marketingOptIn ?? false,
         updatedAt: new Date(),
       })
@@ -74,6 +77,7 @@ export async function saveProfile(params: SaveProfileParams) {
         username,
         bio,
         email,
+        x_handle,
         marketingOptIn: marketingOptIn ?? false,
       })
       .returning();

--- a/app/profile/[[...address]]/page.tsx
+++ b/app/profile/[[...address]]/page.tsx
@@ -310,10 +310,13 @@ export default function ProfilePage() {
           <DialogHeader>
             <DialogTitle>Edit Profile</DialogTitle>
             <DialogDescription>
-              Update your profile information. This will be visible to others.
+              Update your profile information.
             </DialogDescription>
           </DialogHeader>
           <div className="grid gap-4 py-4">
+            <p className="text-sm text-muted-foreground">
+              Username and Bio will be visible to others.
+            </p>
             <div className="grid gap-2">
               <Label htmlFor="username">Username</Label>
               <Input
@@ -340,6 +343,36 @@ export default function ProfilePage() {
               <p className="text-xs text-muted-foreground">
                 {editBio.length}/200 characters
               </p>
+            </div>
+            <p className="text-md text-muted-foreground">
+              Communication methods
+            </p>
+            <p className="text-sm text-muted-foreground">
+              Update your communication methods to join the Shelby Breakpoint
+              contest. Will be used to contact you if you win.
+            </p>
+            <p className="text-sm text-muted-foreground">
+              Will not be shared with anyone else.
+            </p>
+            <div className="text-sm text-muted-foreground">
+              <p>How the contest works:</p>
+              <ul className="list-disc pl-5">
+                <li>
+                  Watch and like up to{" "}
+                  <span className="font-bold">five videos</span> in the app
+                </li>
+                <li>Must live in an eligible country for shipping</li>
+              </ul>
+            </div>
+            <div className="text-sm text-muted-foreground">
+              <p>What you can win:</p>
+              <ul className="list-disc pl-5">
+                <li>
+                  Exclusive Shelby Merch Bundle: sweatshirt, t-shirt, mug, tote
+                  bag, notebook, stickers
+                </li>
+                <li>Professional Creator Kit: Mics, camera, and other gear</li>
+              </ul>
             </div>
             <div className="grid gap-2">
               <Label htmlFor="x_handle">X (Twitter) handle</Label>

--- a/app/profile/[[...address]]/page.tsx
+++ b/app/profile/[[...address]]/page.tsx
@@ -54,7 +54,6 @@ export default function ProfilePage() {
   const { data: profile, isLoading: isProfileLoading } = useProfile({
     walletAddress: profileAddress,
   });
-  console.log("profile", profile);
 
   // Save profile mutation (only for own profile)
   const { mutate: saveProfile, isPending: isSavingProfile } = useSaveProfile({

--- a/app/profile/[[...address]]/page.tsx
+++ b/app/profile/[[...address]]/page.tsx
@@ -37,6 +37,7 @@ export default function ProfilePage() {
   const [editBio, setEditBio] = useState("");
   const [editEmail, setEditEmail] = useState("");
   const [editMarketingOptIn, setEditMarketingOptIn] = useState(false);
+  const [editXHandle, setEditXHandle] = useState("");
   const { executeRecaptcha } = useRecaptcha();
 
   // Get address from path params, or use connected wallet address
@@ -53,6 +54,7 @@ export default function ProfilePage() {
   const { data: profile, isLoading: isProfileLoading } = useProfile({
     walletAddress: profileAddress,
   });
+  console.log("profile", profile);
 
   // Save profile mutation (only for own profile)
   const { mutate: saveProfile, isPending: isSavingProfile } = useSaveProfile({
@@ -86,6 +88,7 @@ export default function ProfilePage() {
       username: editUsername || null,
       bio: editBio || null,
       email: editEmail || null,
+      x_handle: editXHandle || null,
       marketingOptIn: editMarketingOptIn,
       recaptchaToken,
     });
@@ -95,6 +98,7 @@ export default function ProfilePage() {
     editBio,
     editEmail,
     editMarketingOptIn,
+    editXHandle,
     executeRecaptcha,
     saveProfile,
   ]);
@@ -103,6 +107,7 @@ export default function ProfilePage() {
     setEditUsername(profile?.username || "");
     setEditBio(profile?.bio || "");
     setEditEmail(profile?.email || "");
+    setEditXHandle(profile?.x_handle || "");
     setEditMarketingOptIn(profile?.marketingOptIn ?? false);
     setIsEditDialogOpen(true);
   };
@@ -335,6 +340,16 @@ export default function ProfilePage() {
               <p className="text-xs text-muted-foreground">
                 {editBio.length}/200 characters
               </p>
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="x_handle">X (Twitter) handle</Label>
+              <Input
+                id="x_handle"
+                type="text"
+                placeholder="Your X (Twitter) handle"
+                value={editXHandle}
+                onChange={(e) => setEditXHandle(e.target.value)}
+              />
             </div>
             <div className="grid gap-2">
               <Label htmlFor="email">Email</Label>

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -36,6 +36,7 @@ export const profiles = sqliteTable("profiles", {
   username: text("username"),
   bio: text("bio"),
   email: text("email"),
+  x_handle: text("x_handle"),
   marketingOptIn: integer("marketing_opt_in", { mode: "boolean" }).default(
     false
   ),


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Add `x_handle` to profiles, wire it through save/update logic, and expose it in the profile edit dialog with minor copy updates.
> 
> - **Backend**
>   - **DB**: Add `x_handle` column to `profiles` in `db/schema.ts`.
>   - **Actions**: Extend `SaveProfileParams` and `saveProfile` in `actions/profiles.ts` to persist `x_handle` on insert/update.
> - **Frontend**
>   - **Profile Edit Dialog** (`app/profile/[[...address]]/page.tsx`): Add X (Twitter) handle field; manage state, initialize from `profile.x_handle`, and submit via `saveProfile`.
>   - Minor copy tweaks and additional contest info in the dialog.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 19a7c5babdeebac6ee0faf4dd074ed2c6c286faa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->