### PR TITLE
Add a contest dialog to the landing page

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,6 @@
 import { getRandomVideos } from "@/actions/videos";
 import ClientOnly from "@/components/client-only";
+import CommunicationMethodsDialog from "@/components/communication-methods-dialog";
 import VideoCarousel from "@/components/video-carousel";
 import { VIDEO_PAGE_SIZE } from "@/lib/constants";
 import { generateSeed } from "@/lib/random";
@@ -22,7 +23,7 @@ export default async function Home({
   });
 
   return (
-    <div className=" overflow-hidden pb-16 md:pb-0 flex md:items-center justify-center">
+    <div className="overflow-hidden pb-16 md:pb-0 flex md:items-center justify-center">
       <ClientOnly>
         <VideoCarousel
           initialData={videos}
@@ -37,6 +38,7 @@ export default async function Home({
           }}
         />
       </ClientOnly>
+      <CommunicationMethodsDialog />
     </div>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -37,8 +37,8 @@ export default async function Home({
             return videos;
           }}
         />
+        <CommunicationMethodsDialog />
       </ClientOnly>
-      <CommunicationMethodsDialog />
     </div>
   );
 }

--- a/app/profile/[[...address]]/page.tsx
+++ b/app/profile/[[...address]]/page.tsx
@@ -338,6 +338,16 @@ export default function ProfilePage() {
                 {editBio.length}/200 characters
               </p>
             </div>
+            <div className="grid gap-2">
+              <Label htmlFor="x_handle">X (Twitter) handle</Label>
+              <Input
+                id="x_handle"
+                type="text"
+                placeholder="Your X (Twitter) handle"
+                value={editXHandle}
+                onChange={(e) => setEditXHandle(e.target.value)}
+              />
+            </div>
             <p className="text-md text-muted-foreground">
               Communication methods
             </p>
@@ -349,21 +359,21 @@ export default function ProfilePage() {
               Will not be shared with anyone else.
             </p>
             <div className="text-sm text-muted-foreground">
-              <p>How the contest works:</p>
+              <p>How to participate in the "Lights. Camera. Serve." Contest</p>
               <ul className="list-disc pl-5">
-                <li>
-                  Watch and like up to{" "}
-                  <span className="font-bold">five videos</span> in the app
-                </li>
+                <li>Watch and engage with videos in the app</li>
                 <li>Must live in an eligible country for shipping</li>
                 <li>
+                  See{" "}
                   <a
                     href="https://shelby.xyz/contest-rules.pdf"
                     target="_blank"
                     rel="noopener noreferrer"
+                    className="underline hover:text-foreground"
                   >
-                    See terms of the contest and eligibility requirements
-                  </a>
+                    Contest Rules
+                  </a>{" "}
+                  for full terms and eligibility
                 </li>
               </ul>
             </div>
@@ -371,21 +381,11 @@ export default function ProfilePage() {
               <p>What you can win:</p>
               <ul className="list-disc pl-5">
                 <li>
-                  Exclusive Shelby Merch Bundle: sweatshirt, t-shirt, mug, tote
-                  bag, notebook, stickers
+                  Shelby Merch Bundle: sweatshirt, t-shirt, mug, tote bag,
+                  notebook, stickers
                 </li>
-                <li>Professional Creator Kit: Mics, camera, and other gear</li>
+                <li>Professional creator gear: mics, camera, lighting</li>
               </ul>
-            </div>
-            <div className="grid gap-2">
-              <Label htmlFor="x_handle">X (Twitter) handle</Label>
-              <Input
-                id="x_handle"
-                type="text"
-                placeholder="Your X (Twitter) handle"
-                value={editXHandle}
-                onChange={(e) => setEditXHandle(e.target.value)}
-              />
             </div>
             <div className="grid gap-2">
               <Label htmlFor="email">Email</Label>
@@ -403,9 +403,6 @@ export default function ProfilePage() {
                   }
                 }}
               />
-              <p className="text-xs text-muted-foreground">
-                Used for notifications and updates.
-              </p>
             </div>
             <div className="flex items-start space-x-3 pt-2">
               <Checkbox
@@ -420,7 +417,26 @@ export default function ProfilePage() {
                   htmlFor="marketing"
                   className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70 cursor-pointer"
                 >
-                  Receive marketing emails
+                  I AGREE TO RECEIVE UPDATES FROM SHELBY FOUNDATION AND
+                  UNDERSTAND I CAN UNSUBSCRIBE AT ANY TIME, AND I HAVE READ AND
+                  ACCEPT THE{" "}
+                  <a
+                    href="https://shelby.xyz/privacy-policy"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="underline hover:text-foreground"
+                  >
+                    PRIVACY POLICY
+                  </a>{" "}
+                  AND{" "}
+                  <a
+                    href="https://shelby.xyz/contest-rules.pdf"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="underline hover:text-foreground"
+                  >
+                    CONTEST RULES
+                  </a>
                 </Label>
               </div>
             </div>
@@ -432,7 +448,13 @@ export default function ProfilePage() {
             >
               Cancel
             </Button>
-            <Button onClick={handleSaveProfile} disabled={isSavingProfile}>
+            <Button
+              onClick={handleSaveProfile}
+              disabled={
+                isSavingProfile ||
+                (!!(editEmail || editXHandle) && !editMarketingOptIn)
+              }
+            >
               {isSavingProfile ? "Saving..." : "Save changes"}
             </Button>
           </DialogFooter>

--- a/components/communication-methods-dialog.tsx
+++ b/components/communication-methods-dialog.tsx
@@ -1,0 +1,198 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { useWallet } from "@aptos-labs/wallet-adapter-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import { toast } from "sonner";
+import useProfile from "@/queries/useProfile";
+import useSaveProfile from "@/mutations/useSaveProfile";
+import { useRecaptcha } from "@/providers/RecaptchaProvider";
+import { useWalletDialog } from "@/providers/WalletDialogProvider";
+
+// Cookie persists for 30 days so user doesn't see dialog repeatedly across sessions
+const COOKIE_NAME = "shelby_contest_dialog_dismissed";
+
+function getCookie(name: string): string | null {
+  if (typeof document === "undefined") return null;
+  const match = document.cookie.match(new RegExp(`(^| )${name}=([^;]+)`));
+  return match ? match[2] : null;
+}
+
+function setCookie(name: string, value: string, days: number = 30) {
+  const date = new Date();
+  date.setTime(date.getTime() + days * 24 * 60 * 60 * 1000);
+  document.cookie = `${name}=${value};expires=${date.toUTCString()};path=/`;
+}
+
+export default function CommunicationMethodsDialog() {
+  const { account, connected } = useWallet();
+  const { openWalletDialog } = useWalletDialog();
+  const [isOpen, setIsOpen] = useState(false);
+  const [editEmail, setEditEmail] = useState("");
+  const [editMarketingOptIn, setEditMarketingOptIn] = useState(false);
+  const { executeRecaptcha } = useRecaptcha();
+
+  const connectedAddress = account?.address?.toString();
+
+  const { data: profile, isLoading: isProfileLoading } = useProfile({
+    walletAddress: connectedAddress,
+  });
+
+  const { mutate: saveProfile, isPending: isSavingProfile } = useSaveProfile({
+    onSuccess: () => {
+      setIsOpen(false);
+      toast.success("Communication methods saved successfully");
+    },
+    onError: () => {
+      toast.error("Failed to save communication methods");
+    },
+  });
+
+  // Show dialog on initial load (with delay)
+  useEffect(() => {
+    const hasDismissed = getCookie(COOKIE_NAME);
+    if (hasDismissed) return;
+
+    // Wait for profile to load if connected
+    if (connected && isProfileLoading) return;
+
+    // Don't show if user already has contact info
+    if (connected && (profile?.email || profile?.x_handle)) return;
+
+    const timer = setTimeout(() => {
+      setIsOpen(true);
+    }, 3000);
+
+    return () => clearTimeout(timer);
+  }, [connected, isProfileLoading, profile]);
+
+  const handleSave = useCallback(async () => {
+    if (!connectedAddress) return;
+
+    let recaptchaToken: string | undefined;
+    if (executeRecaptcha) {
+      try {
+        recaptchaToken = await executeRecaptcha("save_communication_methods");
+      } catch (error) {
+        console.error("reCAPTCHA error:", error);
+        toast.error("Failed to verify you're not a bot. Please try again.");
+        return;
+      }
+    }
+
+    saveProfile({
+      email: editEmail || null,
+      marketingOptIn: editMarketingOptIn,
+      recaptchaToken,
+    });
+  }, [
+    connectedAddress,
+    editEmail,
+    editMarketingOptIn,
+    executeRecaptcha,
+    saveProfile,
+  ]);
+
+  const handleSkip = () => {
+    setCookie(COOKIE_NAME, "true", 30);
+    setIsOpen(false);
+  };
+
+  const handleConnectWallet = () => {
+    openWalletDialog();
+  };
+
+  return (
+    <Dialog open={isOpen} onOpenChange={() => {}}>
+      <DialogContent
+        className="sm:max-w-md max-h-[90vh] flex flex-col"
+        showCloseButton={false}
+      >
+        <DialogHeader>
+          <DialogTitle>Lights. Camera. Serve.</DialogTitle>
+        </DialogHeader>
+        <div className="grid gap-4 py-4 overflow-y-auto flex-1">
+          <p className="text-sm text-muted-foreground">
+            Like videos in the feed for a chance to win Shelby merch and
+            professional creator gear.
+          </p>
+          <p className="text-sm text-muted-foreground">
+            Share your email so we can contact you if you win and to stay up to
+            date on Shelby.
+          </p>
+          <div className="grid gap-2">
+            <Label htmlFor="landing_email">Email</Label>
+            <Input
+              id="landing_email"
+              type="email"
+              placeholder="your@email.com"
+              value={editEmail}
+              onChange={(e) => {
+                const newEmail = e.target.value;
+                setEditEmail(newEmail);
+                if (newEmail && !editMarketingOptIn) {
+                  setEditMarketingOptIn(true);
+                }
+              }}
+            />
+          </div>
+          <div className="flex items-start space-x-3 pt-2">
+            <Checkbox
+              id="landing_marketing"
+              checked={editMarketingOptIn}
+              onCheckedChange={(checked) =>
+                setEditMarketingOptIn(checked === true)
+              }
+            />
+            <div className="grid gap-1.5 leading-none">
+              <Label
+                htmlFor="landing_marketing"
+                className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70 cursor-pointer"
+              >
+                I AGREE TO RECEIVE UPDATES FROM SHELBY FOUNDATION AND UNDERSTAND
+                I CAN UNSUBSCRIBE AT ANY TIME, AND I HAVE READ AND ACCEPT THE{" "}
+                <a
+                  href="https://shelby.xyz/privacy-policy"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="underline hover:text-foreground"
+                >
+                  PRIVACY POLICY
+                </a>
+                .
+              </Label>
+            </div>
+          </div>
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={handleSkip}>
+            Skip
+          </Button>
+          <Button
+            onClick={connected ? handleSave : handleConnectWallet}
+            disabled={
+              isSavingProfile ||
+              (connected && (!editMarketingOptIn || !editEmail))
+            }
+          >
+            {isSavingProfile
+              ? "Saving..."
+              : connected
+              ? "Save"
+              : "Connect wallet to join"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/communication-methods-dialog.tsx
+++ b/components/communication-methods-dialog.tsx
@@ -162,7 +162,7 @@ export default function CommunicationMethodsDialog() {
             </div>
           </div>
         </div>
-        <DialogFooter>
+        <DialogFooter className="gap-2">
           <Button variant="outline" onClick={handleSkip}>
             Skip
           </Button>

--- a/components/communication-methods-dialog.tsx
+++ b/components/communication-methods-dialog.tsx
@@ -19,20 +19,8 @@ import useSaveProfile from "@/mutations/useSaveProfile";
 import { useRecaptcha } from "@/providers/RecaptchaProvider";
 import { useWalletDialog } from "@/providers/WalletDialogProvider";
 
-// Cookie persists for 30 days so user doesn't see dialog repeatedly across sessions
-const COOKIE_NAME = "shelby_contest_dialog_dismissed";
-
-function getCookie(name: string): string | null {
-  if (typeof document === "undefined") return null;
-  const match = document.cookie.match(new RegExp(`(^| )${name}=([^;]+)`));
-  return match ? match[2] : null;
-}
-
-function setCookie(name: string, value: string, days: number = 30) {
-  const date = new Date();
-  date.setTime(date.getTime() + days * 24 * 60 * 60 * 1000);
-  document.cookie = `${name}=${value};expires=${date.toUTCString()};path=/`;
-}
+// Session storage key - dialog won't show again until browser is closed
+const SESSION_KEY = "shelby_contest_dialog_dismissed";
 
 export default function CommunicationMethodsDialog() {
   const { account, connected } = useWallet();
@@ -60,7 +48,7 @@ export default function CommunicationMethodsDialog() {
 
   // Show dialog on initial load (with delay)
   useEffect(() => {
-    const hasDismissed = getCookie(COOKIE_NAME);
+    const hasDismissed = sessionStorage.getItem(SESSION_KEY);
     if (hasDismissed) return;
 
     // Wait for profile to load if connected
@@ -104,7 +92,7 @@ export default function CommunicationMethodsDialog() {
   ]);
 
   const handleSkip = () => {
-    setCookie(COOKIE_NAME, "true", 30);
+    sessionStorage.setItem(SESSION_KEY, "true");
     setIsOpen(false);
   };
 

--- a/components/video-carousel.tsx
+++ b/components/video-carousel.tsx
@@ -35,7 +35,9 @@ export default function VideoCarousel({
   seed = generateSeed(),
   onLoadMore,
 }: VideoCarouselProps) {
-  const [videos, setVideos] = useState<Video[]>(initialData ?? defaultVideos);
+  const [videos, setVideos] = useState<Video[]>(
+    initialData && initialData.length > 0 ? initialData : defaultVideos
+  );
   const scrollListenerRef = useRef<() => void>(() => undefined);
   const listenForScrollRef = useRef(true);
   const hasMoreToLoadRef = useRef(true);


### PR DESCRIPTION
Add Communication Methods Dialog to Landing Page

- A popup dialog on the landing page that collects user email for the Shelby Breakpoint contest.
Features
- Auto-shows after 3 seconds on page load
- Email collection with marketing opt-in checkbox
- Wallet connection flow - "Connect wallet to join" button, dialog stays open during connection
- "Skip" dismisses for the current session (stored in session storage)
- "Save" saves email to user's profile
- Scrollable on mobile for smaller screens

**User Flow**

- User lands on page → dialog appears after 3 seconds
- User enters email and checks the checkbox
- User clicks "Connect wallet to join" → wallet selector opens (dialog stays open)
- After connecting → button changes to "Save"
- User clicks "Save" → email saved, dialog closes

**Conditions for showing**

- User hasn't clicked "Skip" in the current session
- User doesn't already have contact info saved in their profile

https://aptos-org.slack.com/archives/C09PLPPCFUH/p1765378901883649?thread_ts=1765297985.152589&cid=C09PLPPCFUH


https://github.com/user-attachments/assets/0596b07f-aa4f-4b73-8051-a070442079a9

